### PR TITLE
Refactor/animation 행성이 인터랙션 수정

### DIFF
--- a/src/components/Planet/Planet.styles.ts
+++ b/src/components/Planet/Planet.styles.ts
@@ -2,12 +2,13 @@ import styled from "@emotion/styled";
 import { motion } from "motion/react";
 
 export const Wrapper = styled(motion.div)`
-  width: 200px;
-  height: 200px;
+  width: 600px;
+  height: 600px;
   position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
+  border: 2px solid #000;
 `;
 
 export const PlanetCore = styled.div`
@@ -17,7 +18,7 @@ export const PlanetCore = styled.div`
   transform-origin: center;
 `;
 
-export const BodyLayer = styled.div`
+export const BodyLayer = styled(motion.div)`
   position: absolute;
   top: 50%;
   left: 50%;

--- a/src/components/Planet/Planet.styles.ts
+++ b/src/components/Planet/Planet.styles.ts
@@ -8,7 +8,6 @@ export const Wrapper = styled(motion.div)`
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px solid #000;
 `;
 
 export const PlanetCore = styled.div`

--- a/src/components/Planet/Planet.styles.ts
+++ b/src/components/Planet/Planet.styles.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { motion } from "motion/react";
 
-export const Wrapper = styled(motion.div)`
+export const Wrapper = styled.div`
   width: 600px;
   height: 600px;
   position: relative;
@@ -10,7 +10,7 @@ export const Wrapper = styled(motion.div)`
   justify-content: center;
 `;
 
-export const PlanetCore = styled.div`
+export const PlanetCore = styled(motion.div)`
   position: relative;
   width: 120px;
   height: 120px;

--- a/src/components/Planet/Planet.tsx
+++ b/src/components/Planet/Planet.tsx
@@ -1,50 +1,15 @@
+import useShakeAnimation from "../../hooks/useShakeAnimation";
 import DownRing from "../DownRing/DownRing";
 import PlanetBody from "../PlanetBody/PlanetBody";
 import UpRing from "../UpRing/UpRing";
 import * as S from "./Planet.styles";
-import type { TargetAndTransition } from "motion";
-import { useAnimation } from "motion/react";
-
-const shakeAnimations: TargetAndTransition[] = [
-  // 좌우로 빠르게 흔들림
-  {
-    rotate: [0, -10, 10, -10, 0],
-    transition: { duration: 0.5, repeat: 0 },
-  },
-  // 좌우로 크게 흔들림
-  {
-    rotate: [0, 15, -15, 15, 0],
-    transition: { duration: 0.6, repeat: 0 },
-  },
-  // 좌우로 흔들림
-  {
-    x: [0, -5, 5, -5, 0],
-    transition: { duration: 0.4, repeat: 0 },
-  },
-  // 한바퀴 회전
-  {
-    rotate: [0, 360],
-    transition: { duration: 0.8, ease: "easeInOut", repeat: 0 },
-  },
-
-  {
-    y: [0, -10, 0, 10, 0],
-    transition: { duration: 2, ease: "easeInOut", repeat: 0 },
-  },
-];
 
 export default function Planet() {
-  const controls = useAnimation();
-
-  const randomAnimation = () => {
-    const nextAnimation =
-      shakeAnimations[Math.floor(Math.random() * shakeAnimations.length)];
-    controls.start(nextAnimation);
-  };
+  const { shakeControls, setNextRandomShakeAnimation } = useShakeAnimation();
 
   return (
-    <S.Wrapper animate={controls} onTap={randomAnimation}>
-      <S.PlanetCore>
+    <S.Wrapper>
+      <S.PlanetCore animate={shakeControls} onTap={setNextRandomShakeAnimation}>
         <S.UpLayer>
           <UpRing />
         </S.UpLayer>

--- a/src/components/Planet/Planet.tsx
+++ b/src/components/Planet/Planet.tsx
@@ -1,52 +1,49 @@
-import { useState } from "react";
 import DownRing from "../DownRing/DownRing";
 import PlanetBody from "../PlanetBody/PlanetBody";
 import UpRing from "../UpRing/UpRing";
 import * as S from "./Planet.styles";
 import type { TargetAndTransition } from "motion";
+import { useAnimation } from "motion/react";
 
 const shakeAnimations: TargetAndTransition[] = [
   // 좌우로 빠르게 흔들림
   {
     rotate: [0, -10, 10, -10, 0],
-    transition: { duration: 0.5 },
+    transition: { duration: 0.5, repeat: 0 },
   },
   // 좌우로 크게 흔들림
   {
     rotate: [0, 15, -15, 15, 0],
-    transition: { duration: 0.6 },
+    transition: { duration: 0.6, repeat: 0 },
   },
   // 좌우로 흔들림
   {
     x: [0, -5, 5, -5, 0],
-    transition: { duration: 0.4 },
+    transition: { duration: 0.4, repeat: 0 },
   },
   // 한바퀴 회전
   {
     rotate: [0, 360],
-    transition: { duration: 0.8, ease: "easeInOut" },
+    transition: { duration: 0.8, ease: "easeInOut", repeat: 0 },
   },
 
   {
     y: [0, -10, 0, 10, 0],
-    transition: { duration: 2, repeat: Infinity, ease: "easeInOut" },
+    transition: { duration: 2, ease: "easeInOut", repeat: 0 },
   },
 ];
 
 export default function Planet() {
-  const [animation, setAnimation] = useState(
-    shakeAnimations[Math.floor(Math.random() * shakeAnimations.length)],
-  );
+  const controls = useAnimation();
+
+  const randomAnimation = () => {
+    const nextAnimation =
+      shakeAnimations[Math.floor(Math.random() * shakeAnimations.length)];
+    controls.start(nextAnimation);
+  };
 
   return (
-    <S.Wrapper
-      whileTap={animation}
-      onTap={() => {
-        const nextAnimation =
-          shakeAnimations[Math.floor(Math.random() * shakeAnimations.length)];
-        setAnimation(nextAnimation);
-      }}
-    >
+    <S.Wrapper animate={controls} onTap={randomAnimation}>
       <S.PlanetCore>
         <S.UpLayer>
           <UpRing />

--- a/src/components/PlanetEyes/PlanetEyes.tsx
+++ b/src/components/PlanetEyes/PlanetEyes.tsx
@@ -1,3 +1,5 @@
+import { motion } from "framer-motion";
+
 export default function PlanetEyes({
   mousePosition,
   center,
@@ -5,7 +7,7 @@ export default function PlanetEyes({
   mousePosition: { x: number; y: number } | null;
   center: { x: number; y: number };
 }) {
-  const radius = 7;
+  const radius = 10;
 
   const eyeOffsetX = 20;
   const eyeOffsetY = -10;
@@ -44,17 +46,23 @@ export default function PlanetEyes({
 
   return (
     <g>
-      <circle
-        cx={centerLeft.x + leftOffset.x}
-        cy={centerLeft.y + leftOffset.y}
+      <motion.circle
+        animate={{
+          cx: centerLeft.x + leftOffset.x,
+          cy: centerLeft.y + leftOffset.y,
+        }}
         r="4"
         fill="black"
+        transition={{ type: "spring", stiffness: 100, damping: 10 } as const}
       />
-      <circle
-        cx={centerRight.x + rightOffset.x}
-        cy={centerRight.y + rightOffset.y}
+      <motion.circle
+        animate={{
+          cx: centerRight.x + rightOffset.x,
+          cy: centerRight.y + rightOffset.y,
+        }}
         r="4"
         fill="black"
+        transition={{ type: "spring", stiffness: 100, damping: 10 } as const}
       />
     </g>
   );

--- a/src/hooks/useShakeAnimation.ts
+++ b/src/hooks/useShakeAnimation.ts
@@ -1,0 +1,44 @@
+import type { TargetAndTransition } from "motion";
+import { useAnimation } from "motion/react";
+
+const shakeAnimations: TargetAndTransition[] = [
+  // 좌우로 빠르게 흔들림
+  {
+    rotate: [0, -10, 10, -10, 0],
+    transition: { duration: 0.5, repeat: 0 },
+  },
+  // 좌우로 크게 흔들림
+  {
+    rotate: [0, 15, -15, 15, 0],
+    transition: { duration: 0.6, repeat: 0 },
+  },
+  // 좌우로 흔들림
+  {
+    x: [0, -5, 5, -5, 0],
+    transition: { duration: 0.4, repeat: 0 },
+  },
+  // 한바퀴 회전
+  {
+    rotate: [0, 360],
+    transition: { duration: 0.8, ease: "easeInOut", repeat: 0 },
+  },
+
+  {
+    y: [0, -10, 0, 10, 0],
+    transition: { duration: 2, ease: "easeInOut", repeat: 0 },
+  },
+];
+
+const useShakeAnimation = () => {
+  const shakeControls = useAnimation();
+
+  const setNextRandomShakeAnimation = () => {
+    const nextAnimation =
+      shakeAnimations[Math.floor(Math.random() * shakeAnimations.length)];
+    shakeControls.start(nextAnimation);
+  };
+
+  return { shakeControls, setNextRandomShakeAnimation };
+};
+
+export default useShakeAnimation;

--- a/src/stories/components/Planet.stories.tsx
+++ b/src/stories/components/Planet.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import Planet from "../../components/Planet/Planet";
+
+const meta: Meta<typeof Planet> = {
+  title: "Components/Planet",
+  component: Planet,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Planet>;
+
+export const Default: Story = {
+  render: () => <Planet />,
+};


### PR DESCRIPTION
## 📌 관련 이슈
#11 [Refactor] 행성이 인터랙션 수정

## 🚀 설명

* 클릭했을 때 애니메이션은 한 번 실행되고 원래 상태로 돌아오도록 구현
* 호버 했을 때 눈이 다시 원래 위치로 돌아오고, 이 때 끊기지 않고 부드럽게 넘어오도록 애니메이션 추가


## 📸 스크린 샷

https://github.com/user-attachments/assets/47bc21bf-db0e-490d-9b4c-03981b4e2cc2


## 📢 잡담

🥲 눈동자 움직임이 굉장히 버벅입니다 ,, , ,, 인식범위를 확장한건 적용이 되었는데 마우스 위치 계산의 문제인지 답답하게 느리게 따라가네요 ,, 이 부분은 도저히 혼자 gpt 랑 씨름하면서 해봤는데도 도저히 해결이 되지 않아 남겨놨습니다 ㅠㅠ

* Planet으로 Mouseposition 계산을 옮기고 시도해보았는데 wrapper가 svg가 아니라 div라서 좌표 계산을 현재 방식과 동일하게 가져갈 수가 없고 내부에서 한 번 더 변환해줘야 하는 문제가 있습니다 🤔

+) 추가

현재 다른 작업때문에 이 PR이 머지되기전 main 에서 따로 브랜치를 분기 처리하여 작업하고 있는데 moion.circle 로 바뀌면서 눈동자가 제대로 못따라오는 듯 보이긴합니다 ,, 같이 참고해주세요 🥲