### PR TITLE
fix/planet planetCore에 행성이 z-index 고정

### DIFF
--- a/src/components/Planet/Planet.styles.ts
+++ b/src/components/Planet/Planet.styles.ts
@@ -15,6 +15,7 @@ export const PlanetCore = styled(motion.div)`
   width: 120px;
   height: 120px;
   transform-origin: center;
+  z-index: 10;
 `;
 
 export const BodyLayer = styled(motion.div)`


### PR DESCRIPTION
## 📌 관련 이슈

#17 애니메이션 z-index 관련 버그

## 🚀 설명

* 회전 애니메이션이 실행될 경우, transform에 rotate(360deg)가 적용되면서 위성이가 z-index 맨 위로 올라오게 됨

=> transform 이 브라우저에서 stacking context를 생성하게 되고, 현재 PlanetCore에는 z-index가 설정되어 있지 않았어서 발생한 문제

### 해결 과정 중 생긴 의문❓ 
그럼 PlanetCore 하위에 있는 upLayer, downLayer 등에는 z-index가 이미 11~13으로 주어져있었는데 얘네는 무시되는가?

동일 stacking context 안에서는 z-index 우선순위가 비교되는데, transform 되면서 PlanetCore는 새로운 Stacking Context가 되고 나머지 ring 레이어들이 z-index가 있어도 다른 stacking context에 속해 PlanetCore 보다 위로 올라갈 수 없음

### 해결 방안 💡
PlanetCore에 명시적으로 z-index 설정

### 참고
아래와 같은 요소도 stacking context 새로 만들 수 있음

- position: fixed, position: absolute + z-index
- opacity < 1
- transform

## 📸 스크린 샷

따로 첨부 하지 않아도 될 것 같아서 안하긴 했어유 🤔

## 📢 잡담

https://velog.io/@rlwjd31/z-index-stacking-context

참고한 글 입니다 ~! 새롭고 신기한 issue 네요 😊 z-index를 기본적으로 그냥 레이어 겹치는 정도로만 이해를 하고 있었다 보니 정확하게 어떤 구조를 가지고 레이아웃을 잡나 했는데, 덕분에 새로운 사실 알게 되었습니당 🦩
