### PR TITLE
fix/opacity emotion이 motion에 의해 덮어씌워지는 현상 수정

### DIFF
--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -7,9 +7,11 @@ const IconButton = ({ size, name, isDarkMode, ...rest }: IconButtonProps) => {
   return (
     <S.Button
       {...rest}
+      disabled={rest.disabled}
       size={size}
       name={iconName}
       whileHover={rest.disabled ? undefined : rest.whileHover}
+      animate={{ opacity: rest.disabled ? 0.2 : 0.5 }}
     />
   );
 };


### PR DESCRIPTION
## 📌 관련 이슈

close #31 opacity 조절

## 🚀 설명
현재 마지막 스페셜 행성이를 뽑을 때, 뽑고 나서는 주사위가 비활성화 상태로 있어야 하는데 새로고침해야만 활성화 되는 현상 발생

> html element로 찍어보면 disabled 속성이 안붙고 opacity는 0.5로 덮어씌워지고 있었음

### 💡 새롭게 알게된 사실

Motion - inline style로 DOM 에 직접 넣기 때문에 emotion 보다 우선 순위가 높게 됨

즉, 동적인 상태는 motion prop으로 작성하는 것이 충돌을 방지할 수 있는 방법이기 때문에 동적으로 opacity 조절하는 것을 animate 속성으로 바꾸었습니다 !

[유사 이슈]
https://github.com/motiondivision/motion/issues/1666?utm_source=chatgpt.com?utm_source=chatgpt.com

## 📸 스크린 샷

https://github.com/user-attachments/assets/dbe11394-189b-4cb3-ad40-5f9a5920c6d1



## 📢 잡담

상태값의 문제인줄 알았더니만,, 애니메이션 라이브러리 문제였네요 ㅋㅋㅋㅋㅋㅋㅋ 그래도 다행히 원인이 밝혀져 해결하였습니다 🥲

