### PR TITLE
Feature/eye 즉각적으로 반응하는 눈동자 움직임 구현

### DIFF
--- a/src/components/EyeMoving/EyeMoving.styles.ts
+++ b/src/components/EyeMoving/EyeMoving.styles.ts
@@ -1,5 +1,35 @@
 import styled from "@emotion/styled";
+import { motion } from "motion/react";
 
-export const Container = styled.div`
-  border: 1px solid black;
+export const OuterContainer = styled.div<{
+  size: number;
+  showRecognitionZone: boolean;
+}>`
+  position: relative;
+  width: ${({ size }) => size}px;
+  height: ${({ size }) => size}px;
+  border: ${({ showRecognitionZone }) =>
+    showRecognitionZone && "1px solid black"};
 `;
+
+export const InnerRecognitionZone = styled.div<{
+  size: number;
+}>`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: ${({ size }) => size}px;
+  height: ${({ size }) => size}px;
+  border: 1px solid black;
+  border-radius: 50%;
+`;
+
+export const MovingContainer = styled(motion.div)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+export const AnimationContent = styled(motion.div)``;

--- a/src/components/EyeMoving/EyeMoving.styles.ts
+++ b/src/components/EyeMoving/EyeMoving.styles.ts
@@ -1,0 +1,5 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+  border: 1px solid black;
+`;

--- a/src/components/EyeMoving/EyeMoving.tsx
+++ b/src/components/EyeMoving/EyeMoving.tsx
@@ -41,7 +41,7 @@ const EyeMoving = ({
             x: offset.x,
             y: offset.y,
           }}
-          transition={{ type: "spring", stiffness: 300, damping: 20 }}
+          transition={{ type: "spring", stiffness: 300, damping: 50 }}
         >
           {children}
         </S.AnimationContent>

--- a/src/components/EyeMoving/EyeMoving.tsx
+++ b/src/components/EyeMoving/EyeMoving.tsx
@@ -36,13 +36,7 @@ const EyeMoving = ({
     >
       <S.MovingContainer>
         {showRecognitionZone && <S.InnerRecognitionZone size={innerSafeSize} />}
-        <S.AnimationContent
-          animate={{
-            x: offset.x,
-            y: offset.y,
-          }}
-          transition={{ type: "spring", stiffness: 300, damping: 50 }}
-        >
+        <S.AnimationContent style={{ x: offset.x, y: offset.y }}>
           {children}
         </S.AnimationContent>
       </S.MovingContainer>

--- a/src/components/EyeMoving/EyeMoving.tsx
+++ b/src/components/EyeMoving/EyeMoving.tsx
@@ -1,7 +1,53 @@
+import { useRef } from "react";
 import * as S from "./EyeMoving.styles";
+import useEyeMoving from "../../hooks/useEyeMoving";
 
-const EyeMoving = () => {
-  return <S.Container>눈동자</S.Container>;
+interface EyeMovingProps {
+  size: number;
+  innerSafeSize?: number;
+  maxMovingValue?: number;
+  showRecognitionZone?: boolean;
+  children: React.ReactNode;
+}
+
+const EyeMoving = ({
+  size,
+  innerSafeSize = 0,
+  maxMovingValue = 10,
+  showRecognitionZone = false,
+  children,
+}: EyeMovingProps) => {
+  const outerRef = useRef<HTMLDivElement>(null);
+
+  const { offset, handleMouseMove, handleMouseLeave } = useEyeMoving(
+    outerRef,
+    size,
+    innerSafeSize,
+    maxMovingValue
+  );
+
+  return (
+    <S.OuterContainer
+      size={size}
+      showRecognitionZone={showRecognitionZone}
+      ref={outerRef}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+    >
+      <S.MovingContainer>
+        {showRecognitionZone && <S.InnerRecognitionZone size={innerSafeSize} />}
+        <S.AnimationContent
+          animate={{
+            x: offset.x,
+            y: offset.y,
+          }}
+          transition={{ type: "spring", stiffness: 300, damping: 20 }}
+        >
+          {children}
+        </S.AnimationContent>
+      </S.MovingContainer>
+    </S.OuterContainer>
+  );
 };
 
 export default EyeMoving;

--- a/src/components/EyeMoving/EyeMoving.tsx
+++ b/src/components/EyeMoving/EyeMoving.tsx
@@ -1,0 +1,7 @@
+import * as S from "./EyeMoving.styles";
+
+const EyeMoving = () => {
+  return <S.Container>눈동자</S.Container>;
+};
+
+export default EyeMoving;

--- a/src/components/Planet/Planet.styles.ts
+++ b/src/components/Planet/Planet.styles.ts
@@ -10,20 +10,34 @@ export const Wrapper = styled.div`
   justify-content: center;
 `;
 
-export const EyeLayer = styled.div`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 13;
-`;
-
 export const PlanetCore = styled(motion.div)`
   position: relative;
   width: 120px;
   height: 120px;
   transform-origin: center;
   z-index: 10;
+`;
+
+export const ClickableOverlay = styled(motion.div)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 125%;
+  height: 125%;
+  border-radius: 50%;
+  z-index: 14;
+  /* 디버깅용
+  cursor: pointer;
+  background-color: rgba(255, 0, 0, 0.1); */
+`;
+
+export const EyeLayer = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 13;
 `;
 
 export const BodyLayer = styled(motion.div)`

--- a/src/components/Planet/Planet.styles.ts
+++ b/src/components/Planet/Planet.styles.ts
@@ -10,6 +10,14 @@ export const Wrapper = styled.div`
   justify-content: center;
 `;
 
+export const EyeLayer = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 13;
+`;
+
 export const PlanetCore = styled(motion.div)`
   position: relative;
   width: 120px;

--- a/src/components/Planet/Planet.tsx
+++ b/src/components/Planet/Planet.tsx
@@ -6,6 +6,8 @@ import PlanetBody from "../PlanetBody/PlanetBody";
 import UpRing from "../UpRing/UpRing";
 import * as S from "./Planet.styles";
 import Backlight from "../Backlight/Backlight";
+import EyeMoving from "../EyeMoving/EyeMoving";
+import PlanetEyes from "../PlanetEyes/PlanetEyes";
 
 export default function Planet({
   isDarkMode = false,
@@ -32,11 +34,19 @@ export default function Planet({
 
   return (
     <S.Wrapper>
-      <S.PlanetCore animate={shakeControls} onTap={setNextRandomShakeAnimation}>
+      <S.PlanetCore animate={shakeControls}>
+        <S.EyeLayer>
+          <EyeMoving size={500} innerSafeSize={200} showRecognitionZone={true}>
+            <PlanetEyes
+              center={{ x: 150, y: 150 }}
+              eyeColor={colors.eyeColor}
+            />
+          </EyeMoving>
+        </S.EyeLayer>
         <S.UpLayer>
           <UpRing color={colors.ringColor} isDarkMode={isDarkMode} />
         </S.UpLayer>
-        <S.BodyLayer>
+        <S.BodyLayer onTap={setNextRandomShakeAnimation}>
           <PlanetBody
             bodyColor={colors.bodyColor}
             eyeColor={colors.eyeColor}

--- a/src/components/Planet/Planet.tsx
+++ b/src/components/Planet/Planet.tsx
@@ -35,13 +35,9 @@ export default function Planet({
   return (
     <S.Wrapper>
       <S.PlanetCore animate={shakeControls}>
+        <S.ClickableOverlay onTap={setNextRandomShakeAnimation} />
         <S.EyeLayer>
-          <EyeMoving
-            size={500}
-            innerSafeSize={200}
-            maxMovingValue={5}
-            showRecognitionZone={true}
-          >
+          <EyeMoving size={500} innerSafeSize={150} maxMovingValue={5}>
             <PlanetEyes
               center={{ x: 150, y: 150 }}
               eyeColor={colors.eyeColor}
@@ -51,7 +47,7 @@ export default function Planet({
         <S.UpLayer>
           <UpRing color={colors.ringColor} isDarkMode={isDarkMode} />
         </S.UpLayer>
-        <S.BodyLayer onTap={setNextRandomShakeAnimation}>
+        <S.BodyLayer>
           <PlanetBody
             bodyColor={colors.bodyColor}
             eyeColor={colors.eyeColor}

--- a/src/components/Planet/Planet.tsx
+++ b/src/components/Planet/Planet.tsx
@@ -36,7 +36,12 @@ export default function Planet({
     <S.Wrapper>
       <S.PlanetCore animate={shakeControls}>
         <S.EyeLayer>
-          <EyeMoving size={500} innerSafeSize={200} showRecognitionZone={true}>
+          <EyeMoving
+            size={500}
+            innerSafeSize={200}
+            maxMovingValue={5}
+            showRecognitionZone={true}
+          >
             <PlanetEyes
               center={{ x: 150, y: 150 }}
               eyeColor={colors.eyeColor}

--- a/src/components/PlanetBody/PlanetBody.tsx
+++ b/src/components/PlanetBody/PlanetBody.tsx
@@ -1,54 +1,19 @@
 import * as S from "./PlanetBody.styles";
-import PlanetEyes from "../PlanetEyes/PlanetEyes";
-import { useRef, useState } from "react";
+
+interface PlanetBodyProps {
+  bodyColor?: string;
+  eyeColor?: string;
+  isDarkMode?: boolean;
+}
 
 export default function PlanetBody({
   bodyColor = "#fff1b7",
   eyeColor = "#000",
   isDarkMode = false,
-}: {
-  bodyColor?: string;
-  eyeColor?: string;
-  isDarkMode?: boolean;
-}) {
-  const [mousePosition, setMousePosition] = useState<{
-    x: number;
-    y: number;
-  } | null>(null);
-  const svgRef = useRef<SVGSVGElement>(null);
-
-  const bodyCenter = { x: 150, y: 150 };
-  const bodyRadius = 100;
-
-  const handleMouseMove = (e: React.MouseEvent<SVGSVGElement>) => {
-    if (!svgRef.current) return;
-
-    const svgPoint = svgRef.current.createSVGPoint();
-    svgPoint.x = e.clientX;
-    svgPoint.y = e.clientY;
-
-    const transformedPoint = svgPoint.matrixTransform(
-      svgRef.current.getScreenCTM()?.inverse()
-    );
-    const dx = transformedPoint.x - bodyCenter.x;
-    const dy = transformedPoint.y - bodyCenter.y;
-    const distance = Math.sqrt(dx * dx + dy * dy);
-
-    setMousePosition(
-      distance <= bodyRadius
-        ? null
-        : { x: transformedPoint.x, y: transformedPoint.y }
-    );
-  };
+}: PlanetBodyProps) {
   return (
     <S.PlanetBodyWrapper>
-      <svg
-        viewBox="0 0 300 300"
-        width="200"
-        height="200"
-        ref={svgRef}
-        onMouseMove={handleMouseMove}
-      >
+      <svg viewBox="0 0 300 300" width="200" height="200">
         <defs>
           <filter
             id="hand-drawn-outline"
@@ -83,12 +48,7 @@ export default function PlanetBody({
           strokeWidth="4"
           filter="url(#hand-drawn-outline)"
         />
-        <PlanetEyes
-          mousePosition={mousePosition}
-          center={{ x: 150, y: 150 }}
-          eyeColor={eyeColor}
-        />
-        <circle cx="150" cy="160" r="4" fill={eyeColor} />
+        <circle cx="150" cy="170" r="4" fill={eyeColor} />
       </svg>
     </S.PlanetBodyWrapper>
   );

--- a/src/components/PlanetEyes/PlanetEyes.tsx
+++ b/src/components/PlanetEyes/PlanetEyes.tsx
@@ -1,16 +1,10 @@
-import { motion } from "framer-motion";
-
 export default function PlanetEyes({
-  mousePosition,
   center,
   eyeColor,
 }: {
-  mousePosition: { x: number; y: number } | null;
   center: { x: number; y: number };
   eyeColor: string;
 }) {
-  const radius = 10;
-
   const eyeOffsetX = 20;
   const eyeOffsetY = -10;
 
@@ -23,49 +17,12 @@ export default function PlanetEyes({
     y: center.y + eyeOffsetY,
   };
 
-  const calcOffset = ({
-    eyeCenter,
-  }: {
-    eyeCenter: { x: number; y: number };
-  }) => {
-    if (!mousePosition) return { x: 0, y: 0 };
-
-    const dx = mousePosition.x - eyeCenter.x;
-    const dy = mousePosition.y - eyeCenter.y;
-    const distance = Math.sqrt(dx * dx + dy * dy);
-
-    if (distance < 1) return { x: 0, y: 0 };
-
-    const scale = Math.min(radius / distance, 1);
-    return {
-      x: dx * scale,
-      y: dy * scale,
-    };
-  };
-
-  const leftOffset = calcOffset({ eyeCenter: centerLeft });
-  const rightOffset = calcOffset({ eyeCenter: centerRight });
-
   return (
-    <g>
-      <motion.circle
-        animate={{
-          cx: centerLeft.x + leftOffset.x,
-          cy: centerLeft.y + leftOffset.y,
-        }}
-        r="4"
-        fill={eyeColor}
-        transition={{ type: "spring", stiffness: 100, damping: 10 } as const}
-      />
-      <motion.circle
-        animate={{
-          cx: centerRight.x + rightOffset.x,
-          cy: centerRight.y + rightOffset.y,
-        }}
-        r="4"
-        fill={eyeColor}
-        transition={{ type: "spring", stiffness: 100, damping: 10 } as const}
-      />
-    </g>
+    <svg viewBox="0 0 300 300" width="200" height="200">
+      <g>
+        <circle cx={centerLeft.x} cy={centerLeft.y} r="4" fill={eyeColor} />
+        <circle cx={centerRight.x} cy={centerRight.y} r="4" fill={eyeColor} />
+      </g>
+    </svg>
   );
 }

--- a/src/hooks/useEyeMoving.ts
+++ b/src/hooks/useEyeMoving.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMotionValue, useSpring } from "framer-motion";
 
 const useEyeMoving = (
   outerRef: React.RefObject<HTMLDivElement | null>,
@@ -6,7 +6,11 @@ const useEyeMoving = (
   innerSafeSize: number,
   maxMovingValue: number
 ) => {
-  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const rawX = useMotionValue(0);
+  const rawY = useMotionValue(0);
+
+  const springX = useSpring(rawX, { stiffness: 300, damping: 30 });
+  const springY = useSpring(rawY, { stiffness: 300, damping: 30 });
 
   const handleMouseMove = (e: React.MouseEvent) => {
     if (!outerRef.current) return;
@@ -25,19 +29,26 @@ const useEyeMoving = (
     const safeRadius = innerSafeSize / 2;
 
     if (distanceFromCenter <= safeRadius) {
-      setOffset({ x: 0, y: 0 });
+      rawX.set(0);
+      rawY.set(0);
       return;
     }
 
     const ratio = Math.min(1, maxMovingValue / distanceFromCenter);
-    setOffset({ x: dx * ratio, y: dy * ratio });
+    rawX.set(dx * ratio);
+    rawY.set(dy * ratio);
   };
 
   const handleMouseLeave = () => {
-    setOffset({ x: 0, y: 0 });
+    rawX.set(0);
+    rawY.set(0);
   };
 
-  return { offset, handleMouseMove, handleMouseLeave };
+  return {
+    offset: { x: springX, y: springY },
+    handleMouseMove,
+    handleMouseLeave,
+  };
 };
 
 export default useEyeMoving;

--- a/src/hooks/useEyeMoving.ts
+++ b/src/hooks/useEyeMoving.ts
@@ -1,0 +1,43 @@
+import { useState } from "react";
+
+const useEyeMoving = (
+  outerRef: React.RefObject<HTMLDivElement | null>,
+  size: number,
+  innerSafeSize: number,
+  maxMovingValue: number
+) => {
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!outerRef.current) return;
+
+    const rect = outerRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    const centerX = size / 2;
+    const centerY = size / 2;
+
+    const dx = x - centerX;
+    const dy = y - centerY;
+
+    const distanceFromCenter = Math.sqrt(dx * dx + dy * dy);
+    const safeRadius = innerSafeSize / 2;
+
+    if (distanceFromCenter <= safeRadius) {
+      setOffset({ x: 0, y: 0 });
+      return;
+    }
+
+    const ratio = Math.min(1, maxMovingValue / distanceFromCenter);
+    setOffset({ x: dx * ratio, y: dy * ratio });
+  };
+
+  const handleMouseLeave = () => {
+    setOffset({ x: 0, y: 0 });
+  };
+
+  return { offset, handleMouseMove, handleMouseLeave };
+};
+
+export default useEyeMoving;

--- a/src/stories/components/EyeMoving.stories.tsx
+++ b/src/stories/components/EyeMoving.stories.tsx
@@ -1,13 +1,21 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import EyeMoving from "../../components/EyeMoving/EyeMoving";
 
-const meta = {
+const meta: Meta<typeof EyeMoving> = {
   title: "Components/EyeMoving",
   component: EyeMoving,
-} satisfies Meta<typeof EyeMoving>;
+};
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    size: 500,
+    innerSafeSize: 200,
+    maxMovingValue: 10,
+    showRecognitionZone: true,
+    children: <div>⭐ ⭐</div>,
+  },
+};

--- a/src/stories/components/EyeMoving.stories.tsx
+++ b/src/stories/components/EyeMoving.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import EyeMoving from "../../components/EyeMoving/EyeMoving";
+
+const meta = {
+  title: "Components/EyeMoving",
+  component: EyeMoving,
+} satisfies Meta<typeof EyeMoving>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## 📌 관련 이슈

- close #33 

## 🚀 설명

### 관심사 분리
- 자식 요소를 마우스 이동에 따라 움직이게 하는 컴포넌트인 EyeMoving 컴포넌트 구현
```ts
interface EyeMovingProps {
  size: number;  // 마우스 인식 범위
  innerSafeSize?: number;  // 마우스 안쪽 인식불가 범위
  maxMovingValue?: number;  // 눈동자 움직임 계수
  showRecognitionZone?: boolean;  // 마우스를 인식할 수 있는 범위 표시 (디버깅용)
  children: React.ReactNode;  // 자식 요소
}
```
- 기존 PlanetEyes는 svg로 눈동자를 그려주기만 함
### 트러블 슈팅
- 마우스를 추적하는 넓은 영역이 가장 위쪽에 있어야 눈이 보이므로, 이 때문에 행성이 몸통의 클릭 애니메이션이 실행되지 않는 현상 발생
- **Planet의 가장 앞쪽(z-index)에 ClickableOverlay를 두어 클릭을 받을 수 있도록 구조 변경**

## 📸 스크린 샷

https://github.com/user-attachments/assets/cf5a7d83-9832-4fe5-912a-a76a651c1cfc

## 📢 잡담

추가적인 Layer를 두지않고 [pointer-events](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events)를 조절해서 해결해보려니까 잘 되지 않고, 오히려 코드가 더 지저분해보이더라구요 🥲

그냥 Overlay 하나 추가해서 최상단에 터치 영역을 두는 게 가장 깔끔한 해결책이었던 것 같습니다!